### PR TITLE
Rename get_envvars to get_token.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,4 +4,5 @@ Contributors
 ------------
 
 * Patrick Pierson
-* Kelly Plummer 
+* Kelly Plummer
+* Matt Layman

--- a/pyionic/core.py
+++ b/pyionic/core.py
@@ -7,7 +7,7 @@ class Analysis:
     '''The Analysis class interacts with the Animal endpoints to return
     Analysis data. The data returned is json formated.'''
     def __init__(self):
-        self.token = helpers.get_envvars()
+        self.token = helpers.get_token()
         self.endpoint = helpers.get_api_endpoint()
         self.url = '/v1/animal/'
 
@@ -22,7 +22,7 @@ class Analysis:
 
 class Projects:
     def __init__(self):
-        self.token = helpers.get_envvars()
+        self.token = helpers.get_token()
         self.endpoint = helpers.get_api_endpoint()
         self.url = '/v1/project/'
 
@@ -37,7 +37,7 @@ class Projects:
 
 class Rulesets:
     def __init__(self):
-        self.token = helpers.get_envvars()
+        self.token = helpers.get_token()
         self.endpoint = helpers.get_api_endpoint()
         self.url = '/v1/ruleset/'
 
@@ -56,7 +56,7 @@ class Rulesets:
 
 class Scanner:
     def __init__(self):
-        self.token = helpers.get_envvars()
+        self.token = helpers.get_token()
         self.endpoint = helpers.get_api_endpoint()
         self.url = '/v1/scanner/'
 
@@ -72,7 +72,7 @@ class Scanner:
 
 class Teams:
     def __init__(self):
-        self.token = helpers.get_envvars()
+        self.token = helpers.get_token()
         self.endpoint = helpers.get_api_endpoint()
         self.url = '/v1/teams/'
 
@@ -84,7 +84,7 @@ class Teams:
 
 class Users:
     def __init__(self):
-        self.token = helpers.get_envvars()
+        self.token = helpers.get_token()
         self.endpoint = helpers.get_api_endpoint()
         self.url = '/v1/users/'
 
@@ -95,7 +95,7 @@ class Users:
 
 class Vulnerability:
     def __init__(self):
-        self.token = helpers.get_envvars()
+        self.token = helpers.get_token()
         self.endpoint = helpers.get_api_endpoint()
         self.url = '/v1/vulnerability/'
 

--- a/pyionic/helpers.py
+++ b/pyionic/helpers.py
@@ -2,13 +2,12 @@ import os
 import sys
 
 
-def get_envvars():
+def get_token():
     """Get Ion Channel token from envvars."""
-    if os.environ.get('IONCHANNEL_SECRET_KEY') is not None:
+    try:
         return os.environ['IONCHANNEL_SECRET_KEY']
-    else:
-        print('Ion Channel Token not set')
-        sys.exit(1)
+    except KeyError:
+        sys.exit('Ion Channel Token not set')
 
 
 def get_api_endpoint():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,21 +9,22 @@ import unittest
 class TestHelpers(unittest.TestCase):
     """Basic test cases for helpers usage."""
 
-    def test_get_token_missing(self):
-        """Exit when the IONCHANNEL_SECRET_KEY is not set."""
-        token = os.environ.get('IONCHANNEL_SECRET_KEY')
-        token = '' if token is None else token
-        try:
-            del os.environ['IONCHANNEL_SECRET_KEY']
-        except KeyError:
-            # The variable may already be unset. If so, ignore the exception.
-            pass
+    # FIXME: Trying to see if this test is causing problems.
+    # def test_get_token_missing(self):
+    #     """Exit when the IONCHANNEL_SECRET_KEY is not set."""
+    #     token = os.environ.get('IONCHANNEL_SECRET_KEY')
+    #     token = '' if token is None else token
+    #     try:
+    #         del os.environ['IONCHANNEL_SECRET_KEY']
+    #     except KeyError:
+    #         # The variable may already be unset. If so, ignore the exception.
+    #         pass
 
-        with self.assertRaises(SystemExit):
-            helpers.get_token()
+    #     with self.assertRaises(SystemExit):
+    #         helpers.get_token()
 
-        # Restore the secret key for other tests.
-        os.environ['IONCHANNEL_SECRET_KEY'] = token
+    #     # Restore the secret key for other tests.
+    #     os.environ['IONCHANNEL_SECRET_KEY'] = token
 
     def test_get_api_endpoint(self):
         os.environ['IONCHANNEL_ENDPOINT_URL'] = 'https://api.ionchannel.io'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,12 +9,21 @@ import unittest
 class TestHelpers(unittest.TestCase):
     """Basic test cases for helpers usage."""
 
-    # def test_get_envvars(self):
-    #     with self.assertRaises(SystemExit) as cm:
-    #         envvar_stageing = os.environ['IONCHANNEL_SECRET_KEY']
-    #         del os.environ['IONCHANNEL_SECRET_KEY']
-    #         helpers.get_envvars()
-    #         self.assertEqual(cm.exception.code, 1)
+    def test_get_token_missing(self):
+        """Exit when the IONCHANNEL_SECRET_KEY is not set."""
+        token = os.environ.get('IONCHANNEL_SECRET_KEY')
+        token = '' if token is None else token
+        try:
+            del os.environ['IONCHANNEL_SECRET_KEY']
+        except KeyError:
+            # The variable may already be unset. If so, ignore the exception.
+            pass
+
+        with self.assertRaises(SystemExit):
+            helpers.get_token()
+
+        # Restore the secret key for other tests.
+        os.environ['IONCHANNEL_SECRET_KEY'] = token
 
     def test_get_api_endpoint(self):
         os.environ['IONCHANNEL_ENDPOINT_URL'] = 'https://api.ionchannel.io'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,22 +9,21 @@ import unittest
 class TestHelpers(unittest.TestCase):
     """Basic test cases for helpers usage."""
 
-    # FIXME: Trying to see if this test is causing problems.
-    # def test_get_token_missing(self):
-    #     """Exit when the IONCHANNEL_SECRET_KEY is not set."""
-    #     token = os.environ.get('IONCHANNEL_SECRET_KEY')
-    #     token = '' if token is None else token
-    #     try:
-    #         del os.environ['IONCHANNEL_SECRET_KEY']
-    #     except KeyError:
-    #         # The variable may already be unset. If so, ignore the exception.
-    #         pass
+    def test_get_token_missing(self):
+        """Exit when the IONCHANNEL_SECRET_KEY is not set."""
+        token = os.environ.get('IONCHANNEL_SECRET_KEY')
+        token = '' if token is None else token
+        try:
+            del os.environ['IONCHANNEL_SECRET_KEY']
+        except KeyError:
+            # The variable may already be unset. If so, ignore the exception.
+            pass
 
-    #     with self.assertRaises(SystemExit):
-    #         helpers.get_token()
+        with self.assertRaises(SystemExit):
+            helpers.get_token()
 
-    #     # Restore the secret key for other tests.
-    #     os.environ['IONCHANNEL_SECRET_KEY'] = token
+        # Restore the secret key for other tests.
+        os.environ['IONCHANNEL_SECRET_KEY'] = token
 
     def test_get_api_endpoint(self):
         os.environ['IONCHANNEL_ENDPOINT_URL'] = 'https://api.ionchannel.io'


### PR DESCRIPTION
I thought this would be a bit closer to what it's really doing. I also
changed the function to be a bit more Pythonic by using the exception
rather than guarding for a missing env variable.